### PR TITLE
feat aggregate likers and comments into article feed list endpoint

### DIFF
--- a/backend/src/routes/articles.ts
+++ b/backend/src/routes/articles.ts
@@ -19,6 +19,68 @@ type ArticleWithRelations = Prisma.articlesGetPayload<{
     isLiked?: boolean
 };
 
+type ArticleWithFeedMeta = Prisma.articlesGetPayload<{
+    include: typeof listArticleInclude
+}> & {
+    isLiked?: boolean
+};
+
+// 将 article_likes 关系数据序列化为前端点赞人列表所需的结构
+function serializeLiker(like: {
+    user_id: bigint;
+    user: { id: bigint; username: string; nickname: string | null; avatar: string | null };
+}) {
+    return {
+        id: like.user_id.toString(),
+        displayName: like.user.nickname || like.user.username,
+        username: like.user.username,
+        avatar: like.user.avatar
+    };
+}
+
+// 将 comments 关系数据序列化为与 GET /comments/:articleId 一致的扁平结构
+function serializeFeedComment(comment: {
+    id: bigint;
+    content: string;
+    created_at: Date;
+    updated_at: Date;
+    article_id: bigint;
+    user_id: bigint;
+    parent_id: bigint | null;
+    user: { id: bigint; username: string; nickname: string | null; avatar: string | null };
+    parent: {
+        user: { nickname: string | null; username: string };
+    } | null;
+}) {
+    const parentDisplayName = comment.parent?.user.nickname ?? comment.parent?.user.username ?? null;
+    return {
+        id: comment.id.toString(),
+        content: comment.content,
+        created_at: comment.created_at,
+        updated_at: comment.updated_at,
+        article_id: comment.article_id.toString(),
+        user_id: comment.user_id.toString(),
+        parent_id: comment.parent_id?.toString() ?? null,
+        parent_displayName: parentDisplayName,
+        user: {
+            ...comment.user,
+            id: comment.user.id.toString()
+        }
+    };
+}
+
+// 序列化列表场景下的文章：在基础字段之上附加 likers / comments / comment_total
+function serializeFeedArticle(article: ArticleWithFeedMeta) {
+    const { article_likes, comments, _count, ...rest } = article;
+    const base = serializeArticle({ ...rest, isLiked: article.isLiked });
+    return {
+        ...base,
+        likers: (article_likes ?? []).map(serializeLiker),
+        comments: (comments ?? []).map(serializeFeedComment),
+        comment_total: _count?.comments ?? 0
+    };
+}
+
 const articleInclude = {
     user: {
         select: {
@@ -39,6 +101,73 @@ const articleInclude = {
             tag_id: 'asc'
         }
     }
+} satisfies Prisma.articlesInclude;
+
+// 列表场景额外带出的聚合数据：每篇文章的点赞人预览 + 前 N 条评论 + 评论总数
+// 目的是让首页信息流一次请求即可渲染，避免前端对每篇文章再发起点赞/评论请求（N+1 瀑布）
+const FEED_COMMENT_PAGE_SIZE = 3;
+
+const feedMetaInclude = {
+    article_likes: {
+        include: {
+            user: {
+                select: {
+                    id: true,
+                    username: true,
+                    nickname: true,
+                    avatar: true
+                }
+            }
+        },
+        orderBy: {
+            created_at: 'desc'
+        }
+    },
+    comments: {
+        where: {
+            deleted_at: null
+        },
+        orderBy: {
+            created_at: 'asc'
+        },
+        take: FEED_COMMENT_PAGE_SIZE,
+        include: {
+            user: {
+                select: {
+                    id: true,
+                    username: true,
+                    nickname: true,
+                    avatar: true
+                }
+            },
+            parent: {
+                include: {
+                    user: {
+                        select: {
+                            id: true,
+                            username: true,
+                            nickname: true,
+                            avatar: true
+                        }
+                    }
+                }
+            }
+        }
+    },
+    _count: {
+        select: {
+            comments: {
+                where: {
+                    deleted_at: null
+                }
+            }
+        }
+    }
+} satisfies Prisma.articlesInclude;
+
+const listArticleInclude = {
+    ...articleInclude,
+    ...feedMetaInclude
 } satisfies Prisma.articlesInclude;
 
 function normalizeTagNames(input: ArticleTagInput) {
@@ -283,8 +412,8 @@ router.get('/', optionalAuthMiddleware, async (req: Request, res: Response) => {
                 { created_at: 'desc' }, //按时间发布降序排列
                 { id: 'desc' }
             ],
-            //同时查询作者部分信息、文章的相关图片/视频/标签
-            include: articleInclude
+            //列表场景一次性带出作者、图片/视频/标签、点赞人预览、前 N 条评论与评论总数
+            include: listArticleInclude
         })
 
         // 动态计算用户对文章的喜欢状态
@@ -327,8 +456,8 @@ router.get('/', optionalAuthMiddleware, async (req: Request, res: Response) => {
         const totalArticles = await prisma.articles.count({
             where: where
         });
-        // 处理数据，转化BigInt
-        const responseArticles = articleWithLikeStatus.map(serializeArticle);
+        // 处理数据，转化BigInt，并附加点赞人/评论聚合数据
+        const responseArticles = articleWithLikeStatus.map(serializeFeedArticle);
 
         res.status(200).json({
             data: responseArticles,

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -126,41 +126,17 @@ watch(isLogin, (value) => {
 </script>
 
 <template>
-  
+
   <div class="header">
     <div class="background">
       <!-- 如果设置为图片 -->
       <img v-if="isImage" :src="backgroundPath" alt="顶部图片" />
       <!-- 如果设置为视频 -->
-      <video
-        v-else-if="isVideo"
-        ref="backgroundVideoRef"
-        :src="backgroundPath"
-        autoplay
-        muted
-        loop
-        playsinline
-        webkit-playsinline
-        x5-playsinline
-        x5-video-player-type="h5"
-        x5-video-player-fullscreen="false"
-        preload="auto"
-      />
+      <video v-else-if="isVideo" ref="backgroundVideoRef" :src="backgroundPath" autoplay muted loop playsinline
+        webkit-playsinline x5-playsinline x5-video-player-type="h5" x5-video-player-fullscreen="false" preload="auto" />
       <!-- 其他 -->
-      <video
-        v-else
-        ref="backgroundVideoRef"
-        :src="defaultBackground"
-        autoplay
-        muted
-        loop
-        playsinline
-        webkit-playsinline
-        x5-playsinline
-        x5-video-player-type="h5"
-        x5-video-player-fullscreen="false"
-        preload="auto"
-      />
+      <video v-else ref="backgroundVideoRef" :src="defaultBackground" autoplay muted loop playsinline webkit-playsinline
+        x5-playsinline x5-video-player-type="h5" x5-video-player-fullscreen="false" preload="auto" />
     </div>
     <!-- 顶部导航栏 -->
     <div class="top-bar-wrapper">
@@ -168,8 +144,8 @@ watch(isLogin, (value) => {
 
         <div class="top-bar-left">
           <slot name="left" :isBlurred="isBlurred">
-            <Icon :class="['icon', { blurred: isBlurred }]" title="登录/注册">
-              <UserCircleRegular @click="authStore.showAuth" v-if="!isLogin" />
+            <Icon :class="['icon', { blurred: isBlurred }]" title="登录/注册" v-if="!isLogin">
+              <UserCircleRegular @click="authStore.showAuth" />
             </Icon>
           </slot>
         </div>

--- a/frontend/src/components/article/ArticleList.vue
+++ b/frontend/src/components/article/ArticleList.vue
@@ -12,22 +12,11 @@ const scrollTrigger = ref<HTMLElement | null>(null)
 let observer: IntersectionObserver | null = null
 const isShowInputMap = ref<Record<number, boolean>>({})
 
-const fetchNewArticleData = async (articlesToFetch: any[]) => {
-    for (const article of articlesToFetch) {
-        if (!feedStore.articleLikesMap[article.id]) {
-            await feedStore.fetchArticleLikers(article.id);
-        }
-        if (!feedStore.commentsMap[article.id]) {
-            await feedStore.fetchInitialComments(article.id);
-        }
-    }
-}
 // 组件挂载的时候执行
 onMounted(async () => {
     const id = messageStore.show('正在加载文章', 'loading')
     const isSuccess = await feedStore.fetchInitialArticles()
     if (isSuccess) {
-        await fetchNewArticleData(feedStore.articles);
         messageStore.update(id, { type: 'success', text: '文章加载成功', duration: 2000 })
     } else {
         messageStore.update(id, { type: 'error', text: '文章加载失败', duration: 2000 })
@@ -40,14 +29,11 @@ onMounted(async () => {
                 console.log('滚动到底部，加载更多...');
                 const id = messageStore.show('正在加载文章', 'loading')
 
-                const articlesBeforeFetch = feedStore.articles.length
                 const res = await feedStore.fetchMoreArticles()
                 // 消息通知
                 if (res?.status === 0) {
                     messageStore.update(id, { type: 'info', text: '没有更多文章了', duration: 2000 })
                 } else if (res?.status === 1) {
-                    const newArticles = feedStore.articles.slice(articlesBeforeFetch)
-                    await fetchNewArticleData(newArticles)
                     messageStore.update(id, { type: 'success', text: '文章加载成功', duration: 2000 })
                 } else {
                     messageStore.update(id, { type: 'error', text: '文章加载失败', duration: 2000 })
@@ -89,14 +75,10 @@ async function handleSendReply(payload: { articleId: number, content: string, pa
 function handleLoadMoreComments(articleId: number) {
     feedStore.fetchMoreComments(articleId)
 }
-async function loadArticleMeta() {
-    await fetchNewArticleData(feedStore.articles)
-}
 async function handleTagFilter(tag: string) {
     const id = messageStore.show(`正在加载 #${tag}`, 'loading')
     const isSuccess = await feedStore.setActiveTag(tag)
     if (isSuccess) {
-        await loadArticleMeta()
         messageStore.update(id, { type: 'success', text: `已筛选 #${tag}`, duration: 2000 })
     } else {
         messageStore.update(id, { type: 'error', text: '标签筛选失败', duration: 2000 })
@@ -106,7 +88,6 @@ async function clearTagFilter() {
     const id = messageStore.show('正在加载文章', 'loading')
     const isSuccess = await feedStore.clearActiveTag()
     if (isSuccess) {
-        await loadArticleMeta()
         messageStore.update(id, { type: 'success', text: '已显示全部文章', duration: 2000 })
     } else {
         messageStore.update(id, { type: 'error', text: '文章加载失败', duration: 2000 })

--- a/frontend/src/store/feed.ts
+++ b/frontend/src/store/feed.ts
@@ -59,6 +59,30 @@ export const useFeedStore = defineStore('feed', () => {
         return params
     }
 
+    // 将列表接口聚合返回的 likers / comments / comment_total 写入对应的 map
+    // 这样首页信息流一次请求即可渲染，不再对每篇文章单独请求点赞人和评论
+    const applyArticleMeta = (list: articleData[]) => {
+        for (const article of list) {
+            if (article.likers) {
+                articleLikesMap.value[article.id] = article.likers
+            }
+            if (article.comments) {
+                commentsMap.value[article.id] = article.comments
+            }
+            // 用聚合返回的评论总数初始化评论分页状态，与初始评论列表保持一致
+            const total = article.comment_total ?? 0
+            const loaded = article.comments?.length ?? 0
+            commentPagination.value[article.id] = {
+                page: 1,
+                pageSize: 3,
+                total,
+                hasMore: loaded < total,
+                isLoading: false,
+                remaining: Math.max(total - loaded, 0)
+            }
+        }
+    }
+
     // 加载初始文章
     const fetchInitialArticles = async () => {
         // if (articles.value.length > 0) return //防止重复加载文章
@@ -68,6 +92,7 @@ export const useFeedStore = defineStore('feed', () => {
 
             const response = await getArticle(buildArticleParams(1), guestId)
             articles.value = response.data.data
+            applyArticleMeta(articles.value)
             page.value = 1
             hasMore.value = articles.value.length < response.data.total
             return true
@@ -97,6 +122,7 @@ export const useFeedStore = defineStore('feed', () => {
                 const newArticles = response.data.data.filter((a: articleData) => !existingIds.has(a.id));
 
                 articles.value.push(...newArticles);
+                applyArticleMeta(newArticles)
                 page.value += 1
 
                 hasMore.value = articles.value.length < response.data.total

--- a/frontend/src/types/article.ts
+++ b/frontend/src/types/article.ts
@@ -1,3 +1,5 @@
+import type { Comment } from './comments'
+
 export interface articleImageItem {
     id?: string,
     article_id?: string,
@@ -43,7 +45,18 @@ export interface articleData {
     },
     article_images: articleImageItem[],
     article_videos: articleVideoItem[],
-    tags: articleTagItem[]
+    tags: articleTagItem[],
+    // 列表接口聚合返回的点赞人预览、初始评论与评论总数（详情接口不返回）
+    likers?: Liker[],
+    comments?: Comment[],
+    comment_total?: number
+}
+
+export interface Liker {
+    id: string,
+    displayName: string,
+    username: string,
+    avatar: string
 }
 export interface createArticleData {
     content: string,

--- a/frontend/src/types/comments.ts
+++ b/frontend/src/types/comments.ts
@@ -17,10 +17,11 @@ export interface Comment {
     id: string;
     article_id: string;
     user_id: string;
-    parent_id: string;
-    parent_displayName:string
+    parent_id: string | null;
+    parent_displayName: string | null;
     content: string;
     created_at: string;
+    updated_at?: string;
     user: {
         id: string;
         username: string;


### PR DESCRIPTION
- backend: GET /articles now returns likers preview, initial comments (3) and comment_total per article via a single query
- frontend: feed store seeds articleLikesMap/commentsMap/commentPagination from the aggregated response
- ArticleList: remove per-article N+1 sequential fetch of likers/comments
- fix Comment type to allow nullable parent_id/parent_displayName
- minor Header.vue template formatting